### PR TITLE
VZ-4086 - show information about why an app config is not running

### DIFF
--- a/src/ts/jet-composites/vz-console/oamapp/oamapp.tsx
+++ b/src/ts/jet-composites/vz-console/oamapp/oamapp.tsx
@@ -581,11 +581,11 @@ export class ConsoleOAMApplication extends ElementVComponent<Props, State> {
         }
         if (this.state.oamApplication.statusMessage) {
           tabContents.push(
-              <ConsoleMetadataItem
-                  label={Messages.Labels.statusMessage()}
-                  value={this.state.oamApplication.statusMessage}
-                  id={"app-statusdetail-metaitem"}
-              />
+            <ConsoleMetadataItem
+              label={Messages.Labels.statusMessage()}
+              value={this.state.oamApplication.statusMessage}
+              id={"app-statusdetail-metaitem"}
+            />
           );
         }
         if (

--- a/src/ts/jet-composites/vz-console/oamapp/oamapp.tsx
+++ b/src/ts/jet-composites/vz-console/oamapp/oamapp.tsx
@@ -579,6 +579,15 @@ export class ConsoleOAMApplication extends ElementVComponent<Props, State> {
             );
             break;
         }
+        if (this.state.oamApplication.statusMessage) {
+          tabContents.push(
+              <ConsoleMetadataItem
+                  label={Messages.Labels.statusMessage()}
+                  value={this.state.oamApplication.statusMessage}
+                  id={"app-statusdetail-metaitem"}
+              />
+          );
+        }
         if (
           this.state.oamApplication.cluster &&
           this.state.oamApplication.cluster.name !== "local"

--- a/src/ts/jet-composites/vz-console/oamapp/oamapp.tsx
+++ b/src/ts/jet-composites/vz-console/oamapp/oamapp.tsx
@@ -584,7 +584,7 @@ export class ConsoleOAMApplication extends ElementVComponent<Props, State> {
             <ConsoleMetadataItem
               label={Messages.Labels.statusMessage()}
               value={this.state.oamApplication.statusMessage}
-              id={"app-statusdetail-metaitem"}
+              id={"app-statusmessage-metaitem"}
             />
           );
         }

--- a/src/ts/jet-composites/vz-console/service/common.ts
+++ b/src/ts/jet-composites/vz-console/service/common.ts
@@ -114,15 +114,19 @@ export const processOAMData = (
       application.metadata.namespace &&
       application.metadata.name
     ) {
-      const appStatus = (application.status &&
-          application.status.conditions &&
-          application.status.conditions.length > 0) ?
-          getStatusForOAMResource(application.status.conditions[0].status) : Status.Pending;
+      const appStatus =
+        application.status &&
+        application.status.conditions &&
+        application.status.conditions.length > 0
+          ? getStatusForOAMResource(application.status.conditions[0].status)
+          : Status.Pending;
 
-      const appStatusDetail = (appStatus !== Status.Running &&
-          appStatus !== Status.Pending &&
-          application.status?.conditions?.length > 0) ?
-          application.status.conditions[0].message : "";
+      const appStatusDetail =
+        appStatus !== Status.Running &&
+        appStatus !== Status.Pending &&
+        application.status?.conditions?.length > 0
+          ? application.status.conditions[0].message
+          : "";
 
       const oamApplication = <OAMApplication>{
         name: application.metadata.name,

--- a/src/ts/jet-composites/vz-console/service/common.ts
+++ b/src/ts/jet-composites/vz-console/service/common.ts
@@ -17,7 +17,7 @@ import {
 } from "../service/types";
 import * as DateTimeConverter from "ojs/ojconverter-datetime";
 import {
-  getStatusForOAMResource,
+  getStatusForOAMApplication,
   getStatusStateForCluster,
 } from "vz-console/utils/utils";
 
@@ -114,12 +114,7 @@ export const processOAMData = (
       application.metadata.namespace &&
       application.metadata.name
     ) {
-      const appStatus =
-        application.status &&
-        application.status.conditions &&
-        application.status.conditions.length > 0
-          ? getStatusForOAMResource(application.status.conditions[0].status)
-          : Status.Pending;
+      const appStatus = getStatusForOAMApplication(application);
 
       const appStatusDetail =
         appStatus !== Status.Running &&

--- a/src/ts/jet-composites/vz-console/service/common.ts
+++ b/src/ts/jet-composites/vz-console/service/common.ts
@@ -116,19 +116,12 @@ export const processOAMData = (
     ) {
       const appStatus = getStatusForOAMApplication(application);
 
-      const appStatusDetail =
-        appStatus !== Status.Running &&
-        appStatus !== Status.Pending &&
-        application.status?.conditions?.length > 0
-          ? application.status.conditions[0].message
-          : "";
-
       const oamApplication = <OAMApplication>{
         name: application.metadata.name,
         namespace: application.metadata.namespace,
         data: application,
-        status: appStatus,
-        statusMessage: appStatusDetail,
+        status: appStatus.status,
+        statusMessage: appStatus.message,
         createdOn: convertDate(application.metadata.creationTimestamp),
         cluster: { name: clusterName },
       };

--- a/src/ts/jet-composites/vz-console/service/common.ts
+++ b/src/ts/jet-composites/vz-console/service/common.ts
@@ -133,7 +133,7 @@ export const processOAMData = (
         namespace: application.metadata.namespace,
         data: application,
         status: appStatus,
-        statusDetail: appStatusDetail,
+        statusMessage: appStatusDetail,
         createdOn: convertDate(application.metadata.creationTimestamp),
         cluster: { name: clusterName },
       };

--- a/src/ts/jet-composites/vz-console/service/common.ts
+++ b/src/ts/jet-composites/vz-console/service/common.ts
@@ -114,16 +114,22 @@ export const processOAMData = (
       application.metadata.namespace &&
       application.metadata.name
     ) {
+      const appStatus = (application.status &&
+          application.status.conditions &&
+          application.status.conditions.length > 0) ?
+          getStatusForOAMResource(application.status.conditions[0].status) : Status.Pending;
+
+      const appStatusDetail = (appStatus !== Status.Running &&
+          appStatus !== Status.Pending &&
+          application.status?.conditions?.length > 0) ?
+          application.status.conditions[0].message : "";
+
       const oamApplication = <OAMApplication>{
         name: application.metadata.name,
         namespace: application.metadata.namespace,
         data: application,
-        status:
-          application.status &&
-          application.status.conditions &&
-          application.status.conditions.length > 0
-            ? getStatusForOAMResource(application.status.conditions[0].status)
-            : Status.Pending,
+        status: appStatus,
+        statusDetail: appStatusDetail,
         createdOn: convertDate(application.metadata.creationTimestamp),
         cluster: { name: clusterName },
       };

--- a/src/ts/jet-composites/vz-console/service/types.ts
+++ b/src/ts/jet-composites/vz-console/service/types.ts
@@ -37,6 +37,11 @@ export enum Status {
   Inactive = "Inactive",
 }
 
+export interface OAMAppStatusInfo {
+  status: string;
+  message?: string;
+}
+
 export interface FetchApiSignature {
   // eslint-disable-next-line no-undef
   (input: string | Request, init?: RequestInit): Promise<Response>;

--- a/src/ts/jet-composites/vz-console/service/types.ts
+++ b/src/ts/jet-composites/vz-console/service/types.ts
@@ -149,7 +149,7 @@ export interface OAMApplication {
   namespace?: string;
   data?: any;
   status?: Status;
-  statusDetail: string;
+  statusMessage: string;
   // eslint-disable-next-line no-use-before-define
   componentInstances?: OAMComponentInstance[];
   createdOn?: string;

--- a/src/ts/jet-composites/vz-console/service/types.ts
+++ b/src/ts/jet-composites/vz-console/service/types.ts
@@ -149,6 +149,7 @@ export interface OAMApplication {
   namespace?: string;
   data?: any;
   status?: Status;
+  statusDetail: string;
   // eslint-disable-next-line no-use-before-define
   componentInstances?: OAMComponentInstance[];
   createdOn?: string;

--- a/src/ts/jet-composites/vz-console/utils/Messages.ts
+++ b/src/ts/jet-composites/vz-console/utils/Messages.ts
@@ -193,6 +193,7 @@ export const Labels = {
   state: () => Translations.getTranslatedString("labels.state"),
   sortBy: () => Translations.getTranslatedString("labels.sortBy"),
   status: () => Translations.getTranslatedString("labels.status"),
+  statusMessage: () => Translations.getTranslatedString("labels.statusMessage"),
   ns: () => Translations.getTranslatedString("labels.ns"),
   resources: () => Translations.getTranslatedString("labels.resources"),
   components: () => Translations.getTranslatedString("labels.components"),

--- a/src/ts/jet-composites/vz-console/utils/resources/nls/en/strings.ts
+++ b/src/ts/jet-composites/vz-console/utils/resources/nls/en/strings.ts
@@ -139,6 +139,7 @@ export = {
     state: "State",
     sortBy: "Sort by:",
     status: "Status",
+    statusMessage: "Status Message",
     ns: "Namespace",
     resources: "Resources",
     components: "Components",

--- a/src/ts/jet-composites/vz-console/utils/utils.ts
+++ b/src/ts/jet-composites/vz-console/utils/utils.ts
@@ -26,15 +26,26 @@ export const getDefaultRouter = (): CoreRouter => {
 export const isIterable = (object) =>
   object != null && typeof object[Symbol.iterator] === "function";
 
-export const getStatusForOAMResource = (resourceStatus: string): string => {
+export const getStatusForOAMApplication = (application: any): string => {
   let status = Status.Pending;
-  switch (resourceStatus) {
-    case "True":
-      status = Status.Running;
-      break;
-    case "False":
-      status = Status.Terminated;
-      break;
+  if (
+    application.status &&
+    application.status.conditions &&
+    application.status.conditions.length > 0
+  ) {
+    // Find the condition of type "Synced" - True means OAM sync succeeded, False means it failed.
+    const syncedCondition = application.conditions.find(
+      (cond) => cond.type === "Synced"
+    );
+    const appSyncedStatus = syncedCondition ? syncedCondition.status : "False";
+    switch (appSyncedStatus) {
+      case "True":
+        status = Status.Running;
+        break;
+      case "False":
+        status = Status.Terminated;
+        break;
+    }
   }
   return status;
 };

--- a/src/ts/jet-composites/vz-console/utils/utils.ts
+++ b/src/ts/jet-composites/vz-console/utils/utils.ts
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 import * as ko from "knockout";
-import { Status } from "vz-console/service/types";
+import { OAMAppStatusInfo, Status } from "vz-console/service/types";
 import CoreRouter = require("ojs/ojcorerouter");
 
 export const getQueryParam = (paramName: string): string => {
@@ -26,8 +26,11 @@ export const getDefaultRouter = (): CoreRouter => {
 export const isIterable = (object) =>
   object != null && typeof object[Symbol.iterator] === "function";
 
-export const getStatusForOAMApplication = (application: any): string => {
+export const getStatusForOAMApplication = (
+  application: any
+): OAMAppStatusInfo => {
   let status = Status.Pending;
+  let message;
   if (
     application.status &&
     application.status.conditions &&
@@ -38,6 +41,7 @@ export const getStatusForOAMApplication = (application: any): string => {
       (cond) => cond.type === "Synced"
     );
     const appSyncedStatus = syncedCondition ? syncedCondition.status : "False";
+    message = syncedCondition ? syncedCondition.message : "";
     switch (appSyncedStatus) {
       case "True":
         status = Status.Running;
@@ -47,7 +51,7 @@ export const getStatusForOAMApplication = (application: any): string => {
         break;
     }
   }
-  return status;
+  return <OAMAppStatusInfo>{ status, message };
 };
 
 export const getStatusStateForCluster = (resourceStatus: string): string => {

--- a/src/ts/jet-composites/vz-console/utils/utils.ts
+++ b/src/ts/jet-composites/vz-console/utils/utils.ts
@@ -34,7 +34,7 @@ export const getStatusForOAMApplication = (application: any): string => {
     application.status.conditions.length > 0
   ) {
     // Find the condition of type "Synced" - True means OAM sync succeeded, False means it failed.
-    const syncedCondition = application.conditions.find(
+    const syncedCondition = application.status.conditions.find(
       (cond) => cond.type === "Synced"
     );
     const appSyncedStatus = syncedCondition ? syncedCondition.status : "False";


### PR DESCRIPTION
1. When an app config is not running e.g. on a managed cluster, show the information from the app config as to why it is not running.
2. Grab the status information from the OAM app's "Synced" condition type instead of from the 0th condition. 