### PR TITLE
VZ-5029 Remove error when VMC has no apiUrl in status, show component without a link and with status info if all apps pending

### DIFF
--- a/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
+++ b/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
@@ -485,9 +485,9 @@ export class VerrazzanoApi {
         }
 
         if (!vmc.status || !vmc.status.apiUrl) {
-          throw new Error(
-            Messages.Error.errFetchApiURLFromVMCError(clusterName)
-          );
+          // the cluster for this VMC is likely not yet fully registered. Return an empty string
+          // so that we don't try to fetch from the cluster
+          return "";
         }
 
         return vmc.metadata.name;


### PR DESCRIPTION
merge to release-1.2 branch
