### PR TITLE
VZ-4910: Remove npm from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN yum install -y krb5-libs \
     && yum install -y oracle-nodejs-release-el7 \
     && yum install -y nodejs \
     && yum install -y openssl \
+    && npm install -g npm@latest \
     && mkdir /verrazzano \
     && mkdir /licenses \
     && yum clean all \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN yum install -y krb5-libs \
     && yum install -y oracle-nodejs-release-el7 \
     && yum install -y nodejs \
     && yum install -y openssl \
-    && npm install -g npm@latest \
     && mkdir /verrazzano \
     && mkdir /licenses \
     && yum clean all \
@@ -24,7 +23,10 @@ COPY server.js /verrazzano/
 COPY generate-env.js /verrazzano/
 COPY package.json /verrazzano/
 WORKDIR /verrazzano/
-RUN npm install --save express express-http-proxy
+
+RUN npm install --save express express-http-proxy \
+    && rm -rf /usr/bin/npm /usr/lib/node_modules/npm
+
 HEALTHCHECK --interval=1m --timeout=10s \
   CMD /verrazzano/livenessProbe.sh
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
             }
             post {
                 always {
-                    archiveArtifacts artifacts: '**/scanning-report.json', allowEmptyArchive: true
+                    archiveArtifacts artifacts: '**/scanning-report*.json', allowEmptyArchive: true
                 }
             }
         }


### PR DESCRIPTION
This PR removes `npm` from the Console image, since it's not needed once packages are installed. I manually installed the image into a cluster and did some basic validation of the UI. I'm also running the acceptance tests using this image.

This PR also includes a fix to the Jenkinsfile; it was failing on archiving artifacts because the file pattern was wrong.