### PR TITLE
VZ-4290 Fix the OAM application display for missing metadata

### DIFF
--- a/.verrazzano-development-version
+++ b/.verrazzano-development-version
@@ -1,4 +1,4 @@
 # Copyright (C) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-verrazzano-development-version=1.1.2
+verrazzano-development-version=1.1.3

--- a/.verrazzano-development-version
+++ b/.verrazzano-development-version
@@ -1,4 +1,4 @@
 # Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-verrazzano-development-version=1.1.0
+verrazzano-development-version=1.1.1

--- a/.verrazzano-development-version
+++ b/.verrazzano-development-version
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (C) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-verrazzano-development-version=1.1.1
+verrazzano-development-version=1.1.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (C) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 FROM ghcr.io/oracle/oraclelinux:7-slim
@@ -22,7 +22,7 @@ COPY start.sh /verrazzano/
 COPY server.js /verrazzano/
 COPY generate-env.js /verrazzano/
 COPY package.json /verrazzano/
-RUN cd /verrazzano/
+WORKDIR /verrazzano/
 RUN npm install --save express express-http-proxy
 HEALTHCHECK --interval=1m --timeout=10s \
   CMD /verrazzano/livenessProbe.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
             when { not { buildingTag() } }
             steps {
                 script {
-                    clairScanTemp "${env.DOCKER_REPO}/${env.DOCKER_NAMESPACE}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
+                    scanContainerImage "${env.DOCKER_REPO}/${env.DOCKER_NAMESPACE}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
                 }
             }
             post {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -14,6 +14,7 @@
 
   // eslint-disable-next-line no-undef
   requirejs.config({
+    waitSeconds: 25,
     baseUrl: "/js",
 
     paths:

--- a/src/ts/jet-composites/vz-console/oamapp/oamapp.tsx
+++ b/src/ts/jet-composites/vz-console/oamapp/oamapp.tsx
@@ -232,6 +232,7 @@ export class ConsoleOAMApplication extends ElementVComponent<Props, State> {
     workload: any,
     componentMetadata: any
   ): { name: string; namespace: string } {
+    console.log(`WORKLOAD: ${JSON.stringify(workload)}`);
     if (workload.kind.toLowerCase().startsWith("verrazzano")) {
       let name = "";
       let namespace = "";

--- a/src/ts/jet-composites/vz-console/oamapp/oamapp.tsx
+++ b/src/ts/jet-composites/vz-console/oamapp/oamapp.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 import {
@@ -267,10 +267,7 @@ export class ConsoleOAMApplication extends ElementVComponent<Props, State> {
       };
     }
 
-    if (
-      workload.metadata &&
-      workload.metadata.name
-    ) {
+    if (workload.metadata && workload.metadata.name) {
       return {
         name: workload.metadata.name,
         namespace: workload.metadata.namespace || componentMetadata.namespace,

--- a/src/ts/jet-composites/vz-console/oamapp/oamapp.tsx
+++ b/src/ts/jet-composites/vz-console/oamapp/oamapp.tsx
@@ -232,7 +232,6 @@ export class ConsoleOAMApplication extends ElementVComponent<Props, State> {
     workload: any,
     componentMetadata: any
   ): { name: string; namespace: string } {
-    console.log(`WORKLOAD: ${JSON.stringify(workload)}`);
     if (workload.kind.toLowerCase().startsWith("verrazzano")) {
       let name = "";
       let namespace = "";
@@ -270,12 +269,11 @@ export class ConsoleOAMApplication extends ElementVComponent<Props, State> {
 
     if (
       workload.metadata &&
-      workload.metadata.name &&
-      workload.metadata.namespace
+      workload.metadata.name
     ) {
       return {
         name: workload.metadata.name,
-        namespace: workload.metadata.namespace,
+        namespace: workload.metadata.namespace || componentMetadata.namespace,
       };
     }
 


### PR DESCRIPTION
This fixes a customer reported issue and an issue I came across. The metadata field is read as invalid for the components because an extra parameter is expected. This change makes the code more flexible.