### PR TITLE
VZ-4290 Fix the OAM application display for missing namespace in component

### DIFF
--- a/src/ts/jet-composites/vz-console/oamapp/oamapp.tsx
+++ b/src/ts/jet-composites/vz-console/oamapp/oamapp.tsx
@@ -267,14 +267,10 @@ export class ConsoleOAMApplication extends ElementVComponent<Props, State> {
       };
     }
 
-    if (
-      workload.metadata &&
-      workload.metadata.name &&
-      workload.metadata.namespace
-    ) {
+    if (workload.metadata && workload.metadata.name) {
       return {
         name: workload.metadata.name,
-        namespace: workload.metadata.namespace,
+        namespace: workload.metadata.namespace || componentMetadata.namespace,
       };
     }
 


### PR DESCRIPTION
This fixes a customer reported issue and an issue I came across. The metadata field is read as invalid for the components because an extra parameter is expected. This change makes the code more flexible.