### PR TITLE
VZ-6537 - Display instance url in console only when the components are enabled in the VZ CR

### DIFF
--- a/integtest/specs/JaegerMainPage.spec.ts
+++ b/integtest/specs/JaegerMainPage.spec.ts
@@ -6,7 +6,7 @@ import { JaegerHeaderBar } from "../pageObjects/jaeger/JaegerHeaderBar.pom";
 import { expect } from "chai";
 import { Utils } from "../utils/Utils";
 
-describe("Jaeger Home Page", async () => {
+xdescribe("Jaeger Home Page", async () => {
   let jaegerMainPage: JaegerMainPage;
   let jaegerHeaderBar: JaegerHeaderBar;
 

--- a/integtest/specs/JaegerMainPage.spec.ts
+++ b/integtest/specs/JaegerMainPage.spec.ts
@@ -6,7 +6,7 @@ import { JaegerHeaderBar } from "../pageObjects/jaeger/JaegerHeaderBar.pom";
 import { expect } from "chai";
 import { Utils } from "../utils/Utils";
 
-xdescribe("Jaeger Home Page", async () => {
+describe("Jaeger Home Page", async () => {
   let jaegerMainPage: JaegerMainPage;
   let jaegerHeaderBar: JaegerHeaderBar;
 

--- a/integtest/specs/KialiMainPage.spec.ts
+++ b/integtest/specs/KialiMainPage.spec.ts
@@ -6,7 +6,7 @@ import { KialiHeaderBar } from "../pageObjects/kiali/KialiHeaderBar.pom";
 import { expect } from "chai";
 import { Utils } from "../utils/Utils";
 
-xdescribe("Kiali Home Page", async () => {
+describe("Kiali Home Page", async () => {
   let kialiMainPage: KialiMainPage;
   let kialiHeaderBar: KialiHeaderBar;
 

--- a/integtest/specs/MainPage.spec.ts
+++ b/integtest/specs/MainPage.spec.ts
@@ -106,7 +106,7 @@ describe("UI Tests for Home Pages (Console, Grafana, OSD, Prometheus, Kiali, Jae
     });
   });
 
-  xdescribe("Navigate to Kiali home page", (): void => {
+  describe("Navigate to Kiali home page", (): void => {
     it("Wait for navigation to Kiali", async () => {
       await consoleMainPage.navigateToVMI("kiali", 4);
     });
@@ -124,7 +124,7 @@ describe("UI Tests for Home Pages (Console, Grafana, OSD, Prometheus, Kiali, Jae
     });
   });
 
-  xdescribe("Navigate to Jaeger home page", (): void => {
+  describe("Navigate to Jaeger home page", (): void => {
     it("Wait for navigation to Jaeger", async () => {
       await consoleMainPage.navigateToVMI("jaeger", 5);
     });

--- a/integtest/specs/MainPage.spec.ts
+++ b/integtest/specs/MainPage.spec.ts
@@ -124,7 +124,7 @@ describe("UI Tests for Home Pages (Console, Grafana, OSD, Prometheus, Kiali, Jae
     });
   });
 
-  describe("Navigate to Jaeger home page", (): void => {
+  xdescribe("Navigate to Jaeger home page", (): void => {
     it("Wait for navigation to Jaeger", async () => {
       await consoleMainPage.navigateToVMI("jaeger", 5);
     });

--- a/src/ts/jet-composites/vz-console/instance/instance.tsx
+++ b/src/ts/jet-composites/vz-console/instance/instance.tsx
@@ -134,10 +134,11 @@ export class ConsoleInstance extends ElementVComponent<Props, State> {
   };
 
   renderInstanceLinkElement(id, label, url) {
-    if (url == null || typeof url === "undefined") return null;
-    return (
-      <ConsoleMetadataItem id={id} label={label} value={url} link={true} />
-    );
+    if (url) {
+      return (
+        <ConsoleMetadataItem id={id} label={label} value={url} link={true} />
+      );
+    }
   }
 
   protected render() {

--- a/src/ts/jet-composites/vz-console/instance/instance.tsx
+++ b/src/ts/jet-composites/vz-console/instance/instance.tsx
@@ -237,7 +237,7 @@ export class ConsoleInstance extends ElementVComponent<Props, State> {
                       this.state.instance.kialiUrl
                     )}
                     {this.renderInstanceLinkElement(
-                      "instance-jaeger-link-",
+                      "instance-jaeger-link",
                       Messages.Labels.jaeger(),
                       this.state.instance.jaegerUrl
                     )}

--- a/src/ts/jet-composites/vz-console/instance/instance.tsx
+++ b/src/ts/jet-composites/vz-console/instance/instance.tsx
@@ -134,12 +134,10 @@ export class ConsoleInstance extends ElementVComponent<Props, State> {
   };
 
   renderInstanceLinkElement(id, label, url) {
-    if (url !== "") {
-      return (
-        <ConsoleMetadataItem id={id} label={label} value={url} link={true} />
-      );
-    }
-    return null;
+    if (url == null || typeof url === "undefined") return null;
+    return (
+      <ConsoleMetadataItem id={id} label={label} value={url} link={true} />
+    );
   }
 
   protected render() {

--- a/src/ts/jet-composites/vz-console/instance/instance.tsx
+++ b/src/ts/jet-composites/vz-console/instance/instance.tsx
@@ -133,6 +133,34 @@ export class ConsoleInstance extends ElementVComponent<Props, State> {
     this.updateState({ breadcrumbs });
   };
 
+  renderKialiLinkElement() {
+    if (this.state.instance.jaegerUrl != "") {
+      return (
+        <ConsoleMetadataItem
+          label={Messages.Labels.kiali()}
+          value={this.state.instance.kialiUrl}
+          link={true}
+          id={"instance-vmi-link-" + VMIType.Kiali.toLocaleLowerCase()}
+        />
+      );
+    }
+    return null;
+  }
+
+  renderJaegerLinkElement() {
+    if (this.state.instance.jaegerUrl != "") {
+      return (
+        <ConsoleMetadataItem
+          label={Messages.Labels.jaeger()}
+          value={this.state.instance.jaegerUrl}
+          link={true}
+          id={"instance-jaeger-link"}
+        />
+      );
+    }
+    return null;
+  }
+
   protected render() {
     if (this.state.error) {
       return (
@@ -237,20 +265,8 @@ export class ConsoleInstance extends ElementVComponent<Props, State> {
                         VMIType.Opensearch.toLocaleLowerCase()
                       }
                     />
-                    <ConsoleMetadataItem
-                      label={Messages.Labels.kiali()}
-                      value={this.state.instance.kialiUrl}
-                      link={true}
-                      id={
-                        "instance-vmi-link-" + VMIType.Kiali.toLocaleLowerCase()
-                      }
-                    />
-                    <ConsoleMetadataItem
-                      label={Messages.Labels.jaeger()}
-                      value={this.state.instance.jaegerUrl}
-                      link={true}
-                      id={"instance-jaeger-link"}
-                    />
+                    {this.renderKialiLinkElement()}
+                    {this.renderJaegerLinkElement()}
                   </div>
                 </div>
               </div>

--- a/src/ts/jet-composites/vz-console/instance/instance.tsx
+++ b/src/ts/jet-composites/vz-console/instance/instance.tsx
@@ -133,29 +133,10 @@ export class ConsoleInstance extends ElementVComponent<Props, State> {
     this.updateState({ breadcrumbs });
   };
 
-  renderKialiLinkElement() {
-    if (this.state.instance.jaegerUrl != "") {
+  renderInstanceLinkElement(id, label, url) {
+    if (url !== "") {
       return (
-        <ConsoleMetadataItem
-          label={Messages.Labels.kiali()}
-          value={this.state.instance.kialiUrl}
-          link={true}
-          id={"instance-vmi-link-" + VMIType.Kiali.toLocaleLowerCase()}
-        />
-      );
-    }
-    return null;
-  }
-
-  renderJaegerLinkElement() {
-    if (this.state.instance.jaegerUrl != "") {
-      return (
-        <ConsoleMetadataItem
-          label={Messages.Labels.jaeger()}
-          value={this.state.instance.jaegerUrl}
-          link={true}
-          id={"instance-jaeger-link"}
-        />
+        <ConsoleMetadataItem id={id} label={label} value={url} link={true} />
       );
     }
     return null;
@@ -214,59 +195,53 @@ export class ConsoleInstance extends ElementVComponent<Props, State> {
                       value={this.state.instance.mgmtCluster}
                       id={"instance-mgmtcluster-metaitem"}
                     />
-                    <ConsoleMetadataItem
-                      label={Messages.Labels.rancher()}
-                      value={this.state.instance.rancherUrl}
-                      link={true}
-                      id={"instance-rancher-link"}
-                    />
-                    <ConsoleMetadataItem
-                      label={Messages.Labels.keycloak()}
-                      value={this.state.instance.keyCloakUrl}
-                      link={true}
-                      id={"instance-keycloak-link"}
-                    />
+                    {this.renderInstanceLinkElement(
+                      "instance-rancher-link",
+                      Messages.Labels.rancher(),
+                      this.state.instance.rancherUrl
+                    )}
+                    {this.renderInstanceLinkElement(
+                      "instance-keycloak-link",
+                      Messages.Labels.keycloak(),
+                      this.state.instance.keyCloakUrl
+                    )}
                   </div>
                   <div class="oj-sm-6 oj-flex-item">
                     <h3>System Telemetry</h3>
-                    <ConsoleMetadataItem
-                      label={Messages.Labels.kibana()}
-                      value={this.state.instance.kibanaUrl}
-                      link={true}
-                      id={
-                        "instance-vmi-link-" +
-                        VMIType.OpensearchDashboards.toLocaleLowerCase()
-                      }
-                    />
-                    <ConsoleMetadataItem
-                      label={Messages.Labels.grafana()}
-                      value={this.state.instance.grafanaUrl}
-                      link={true}
-                      id={
-                        "instance-vmi-link-" +
-                        VMIType.Grafana.toLocaleLowerCase()
-                      }
-                    />
-                    <ConsoleMetadataItem
-                      label={Messages.Labels.prom()}
-                      value={this.state.instance.prometheusUrl}
-                      link={true}
-                      id={
-                        "instance-vmi-link-" +
-                        VMIType.Prometheus.toLocaleLowerCase()
-                      }
-                    />
-                    <ConsoleMetadataItem
-                      label={Messages.Labels.es()}
-                      value={this.state.instance.elasticUrl}
-                      link={true}
-                      id={
-                        "instance-vmi-link-" +
-                        VMIType.Opensearch.toLocaleLowerCase()
-                      }
-                    />
-                    {this.renderKialiLinkElement()}
-                    {this.renderJaegerLinkElement()}
+                    {this.renderInstanceLinkElement(
+                      "instance-vmi-link-" +
+                        VMIType.OpensearchDashboards.toLocaleLowerCase(),
+                      Messages.Labels.kibana(),
+                      this.state.instance.kibanaUrl
+                    )}
+                    {this.renderInstanceLinkElement(
+                      "instance-vmi-link-" +
+                        VMIType.Grafana.toLocaleLowerCase(),
+                      Messages.Labels.grafana(),
+                      this.state.instance.grafanaUrl
+                    )}
+                    {this.renderInstanceLinkElement(
+                      "instance-vmi-link-" +
+                        VMIType.Prometheus.toLocaleLowerCase(),
+                      Messages.Labels.prom(),
+                      this.state.instance.prometheusUrl
+                    )}
+                    {this.renderInstanceLinkElement(
+                      "instance-vmi-link-" +
+                        VMIType.Opensearch.toLocaleLowerCase(),
+                      Messages.Labels.es(),
+                      this.state.instance.elasticUrl
+                    )}
+                    {this.renderInstanceLinkElement(
+                      "instance-vmi-link-" + VMIType.Kiali.toLocaleLowerCase(),
+                      Messages.Labels.kiali(),
+                      this.state.instance.kialiUrl
+                    )}
+                    {this.renderInstanceLinkElement(
+                      "instance-jaeger-link-",
+                      Messages.Labels.jaeger(),
+                      this.state.instance.jaegerUrl
+                    )}
                   </div>
                 </div>
               </div>

--- a/test/specs/instance/ConsoleInstance.spec.ts
+++ b/test/specs/instance/ConsoleInstance.spec.ts
@@ -73,6 +73,7 @@ async function setup(selectedItem?: string) {
       chai.assert.fail(err);
     });
 }
+
 describe("instance panel screen tests", () => {
   before(async () => {
     sandbox
@@ -253,22 +254,22 @@ describe("instance panel screen tests", () => {
 describe("instance panel screen tests with components disabled", () => {
   before(async () => {
     sandbox
-        .stub(VerrazzanoApi.prototype, <any>"getInstance")
-        .returns(Promise.resolve(instanceWithAllDisabledComponents));
+      .stub(VerrazzanoApi.prototype, <any>"getInstance")
+      .returns(Promise.resolve(instanceWithAllDisabledComponents));
     sandbox
-        .stub(VerrazzanoApi.prototype, <any>"listOAMAppsAndComponents")
-        .returns(Promise.resolve({}));
+      .stub(VerrazzanoApi.prototype, <any>"listOAMAppsAndComponents")
+      .returns(Promise.resolve({}));
     sandbox
-        .stub(VerrazzanoApi.prototype, <any>"listClusters")
-        .returns(Promise.resolve({}));
+      .stub(VerrazzanoApi.prototype, <any>"listClusters")
+      .returns(Promise.resolve({}));
     sandbox
-        .stub(VerrazzanoApi.prototype, <any>"listProjects")
-        .returns(Promise.resolve({}));
+      .stub(VerrazzanoApi.prototype, <any>"listProjects")
+      .returns(Promise.resolve({}));
     await setup()
-        .then(() => console.log("Instance view rendered"))
-        .catch((err) => {
-          chai.assert.fail(err);
-        });
+      .then(() => console.log("Instance view rendered"))
+      .catch((err) => {
+        chai.assert.fail(err);
+      });
   });
 
   after(() => {
@@ -278,54 +279,54 @@ describe("instance panel screen tests with components disabled", () => {
 
   it("renders the vmi links correctly.", async () => {
     const elasticSearchLink = instanceElement.querySelector(
-        `#instance-vmi-link-${VMIType.Opensearch.toLocaleLowerCase()}`
+      `#instance-vmi-link-${VMIType.Opensearch.toLocaleLowerCase()}`
     );
     expect(elasticSearchLink).to.be.null;
 
     const kibanaLink = instanceElement.querySelector(
-        `#instance-vmi-link-${VMIType.OpensearchDashboards.toLocaleLowerCase()}`
+      `#instance-vmi-link-${VMIType.OpensearchDashboards.toLocaleLowerCase()}`
     );
     expect(kibanaLink).to.be.null;
 
     const grafanaLink = instanceElement.querySelector(
-        `#instance-vmi-link-${VMIType.Grafana.toLocaleLowerCase()}`
+      `#instance-vmi-link-${VMIType.Grafana.toLocaleLowerCase()}`
     );
     expect(grafanaLink).to.be.null;
 
     const prometheusLink = instanceElement.querySelector(
-        `#instance-vmi-link-${VMIType.Prometheus.toLocaleLowerCase()}`
+      `#instance-vmi-link-${VMIType.Prometheus.toLocaleLowerCase()}`
     );
     expect(prometheusLink).to.be.null;
   });
 
   it("renders the general details and links correctly.", async () => {
     const statusMetaItem = instanceElement.querySelector(
-        `#instance-status-metaitem`
+      `#instance-status-metaitem`
     );
     expect(statusMetaItem).not.to.be.null;
 
     const versionMetaItem = instanceElement.querySelector(
-        `#instance-version-metaitem`
+      `#instance-version-metaitem`
     );
     expect(versionMetaItem).not.to.be.null;
 
     const mgmtClusterMetaItem = instanceElement.querySelector(
-        `#instance-mgmtcluster-metaitem`
+      `#instance-mgmtcluster-metaitem`
     );
     expect(mgmtClusterMetaItem).not.to.be.null;
 
     const keycloakMetaItem = instanceElement.querySelector(
-        `#instance-keycloak-link`
+      `#instance-keycloak-link`
     );
     expect(keycloakMetaItem).to.be.null;
 
     const rancherMetaItem = instanceElement.querySelector(
-        `#instance-rancher-link`
+      `#instance-rancher-link`
     );
     expect(rancherMetaItem).to.be.null;
 
     const profileMetaItem = instanceElement.querySelector(
-        `#instance-profile-metaitem`
+      `#instance-profile-metaitem`
     );
     expect(profileMetaItem).not.to.be.null;
   });
@@ -335,7 +336,7 @@ describe("instance panel screen tests with components disabled", () => {
     expect(badge).not.to.be.null;
 
     const badgeLabel = instanceElement.querySelector(
-        `.status-badge-status-label`
+      `.status-badge-status-label`
     );
     expect(badgeLabel).not.to.be.null;
     expect(badgeLabel.textContent).to.equal(Messages.Nav.instance());

--- a/test/specs/instance/ConsoleInstance.spec.ts
+++ b/test/specs/instance/ConsoleInstance.spec.ts
@@ -32,6 +32,17 @@ const instance = <Instance>{
   status: "OK",
   profile: "Production",
 };
+
+const instanceWithAllDisabledComponents = <Instance>{
+  id: "0",
+  keyCloakUrl: null,
+  rancherUrl: ``,
+  mgmtCluster: "test",
+  version: "1.0",
+  status: "OK",
+  profile: "Production",
+};
+
 const sandbox = sinon.createSandbox();
 
 async function setup(selectedItem?: string) {
@@ -233,6 +244,98 @@ describe("instance panel screen tests", () => {
 
     const badgeLabel = instanceElement.querySelector(
       `.status-badge-status-label`
+    );
+    expect(badgeLabel).not.to.be.null;
+    expect(badgeLabel.textContent).to.equal(Messages.Nav.instance());
+  });
+});
+
+describe("instance panel screen tests with components disabled", () => {
+  before(async () => {
+    sandbox
+        .stub(VerrazzanoApi.prototype, <any>"getInstance")
+        .returns(Promise.resolve(instanceWithAllDisabledComponents));
+    sandbox
+        .stub(VerrazzanoApi.prototype, <any>"listOAMAppsAndComponents")
+        .returns(Promise.resolve({}));
+    sandbox
+        .stub(VerrazzanoApi.prototype, <any>"listClusters")
+        .returns(Promise.resolve({}));
+    sandbox
+        .stub(VerrazzanoApi.prototype, <any>"listProjects")
+        .returns(Promise.resolve({}));
+    await setup()
+        .then(() => console.log("Instance view rendered"))
+        .catch((err) => {
+          chai.assert.fail(err);
+        });
+  });
+
+  after(() => {
+    fixture.cleanup();
+    sandbox.restore();
+  });
+
+  it("renders the vmi links correctly.", async () => {
+    const elasticSearchLink = instanceElement.querySelector(
+        `#instance-vmi-link-${VMIType.Opensearch.toLocaleLowerCase()}`
+    );
+    expect(elasticSearchLink).to.be.null;
+
+    const kibanaLink = instanceElement.querySelector(
+        `#instance-vmi-link-${VMIType.OpensearchDashboards.toLocaleLowerCase()}`
+    );
+    expect(kibanaLink).to.be.null;
+
+    const grafanaLink = instanceElement.querySelector(
+        `#instance-vmi-link-${VMIType.Grafana.toLocaleLowerCase()}`
+    );
+    expect(grafanaLink).to.be.null;
+
+    const prometheusLink = instanceElement.querySelector(
+        `#instance-vmi-link-${VMIType.Prometheus.toLocaleLowerCase()}`
+    );
+    expect(prometheusLink).to.be.null;
+  });
+
+  it("renders the general details and links correctly.", async () => {
+    const statusMetaItem = instanceElement.querySelector(
+        `#instance-status-metaitem`
+    );
+    expect(statusMetaItem).not.to.be.null;
+
+    const versionMetaItem = instanceElement.querySelector(
+        `#instance-version-metaitem`
+    );
+    expect(versionMetaItem).not.to.be.null;
+
+    const mgmtClusterMetaItem = instanceElement.querySelector(
+        `#instance-mgmtcluster-metaitem`
+    );
+    expect(mgmtClusterMetaItem).not.to.be.null;
+
+    const keycloakMetaItem = instanceElement.querySelector(
+        `#instance-keycloak-link`
+    );
+    expect(keycloakMetaItem).to.be.null;
+
+    const rancherMetaItem = instanceElement.querySelector(
+        `#instance-rancher-link`
+    );
+    expect(rancherMetaItem).to.be.null;
+
+    const profileMetaItem = instanceElement.querySelector(
+        `#instance-profile-metaitem`
+    );
+    expect(profileMetaItem).not.to.be.null;
+  });
+
+  it("renders the status badge correctly.", async () => {
+    const badge = instanceElement.querySelector(`.badge-hexagon`);
+    expect(badge).not.to.be.null;
+
+    const badgeLabel = instanceElement.querySelector(
+        `.status-badge-status-label`
     );
     expect(badgeLabel).not.to.be.null;
     expect(badgeLabel.textContent).to.equal(Messages.Nav.instance());


### PR DESCRIPTION
VZ-6537 Verrazzano Console should display the instance URLs only if the corresponding components are enabled in the VZ CR. If the optional components are disabled explicitly in the VZ CR, currently empty URLs with just the labels are displayed. 

The fix is to display both label and the URL only if the corresponding component is enabled in the VZ CR.