### PR TITLE
Increase default timeout to possible fix lookup problems

### DIFF
--- a/integtest/utils/Wait.ts
+++ b/integtest/utils/Wait.ts
@@ -5,7 +5,7 @@ import { By, until, WebElement } from "selenium-webdriver";
 import { Utils } from "./Utils";
 
 export const PAGE_LOAD_TIMEOUT = 10000;
-const DEFAULT_TIMEOUT = 30000;
+const DEFAULT_TIMEOUT = 50000;
 
 export class Wait {
   public static readonly HEADER_CONTAINER: By = By.className(


### PR DESCRIPTION
Increases the default timeout for looking for elements on the page to be able to fix certain test timeouts