### PR TITLE
VZ-7396: Remove deprecated ingress reference

### DIFF
--- a/integtest/scripts/edit_integ_test_config.sh
+++ b/integtest/scripts/edit_integ_test_config.sh
@@ -9,7 +9,7 @@ INPUT_CONFIG_FILE=$1
 
 CONSOLE_HOST="$(kubectl get ingress verrazzano-ingress -n verrazzano-system -o jsonpath='{.spec.rules[0].host}')"
 GRAFANA_HOST="$(kubectl get ingress vmi-system-grafana -n verrazzano-system -o jsonpath='{.spec.rules[0].host}')"
-OSD_HOST="$(kubectl get ingress vmi-system-kibana -n verrazzano-system -o jsonpath='{.spec.rules[0].host}')"
+OSD_HOST="$(kubectl get ingress vmi-system-opensearchdashboards -n verrazzano-system -o jsonpath='{.spec.rules[0].host}')"
 PROMETHEUS_HOST="$(kubectl get ingress vmi-system-prometheus -n verrazzano-system -o jsonpath='{.spec.rules[0].host}')"
 KIALI_HOST="$(kubectl get ingress vmi-system-kiali -n verrazzano-system -o jsonpath='{.spec.rules[0].host}')"
 JAEGER_HOST="$(kubectl get ingress verrazzano-jaeger -n verrazzano-system -o jsonpath='{.spec.rules[0].host}')"


### PR DESCRIPTION
This PR removes the deprecated reference of Kibana ingress. 