### PR TITLE
VZ-8499: Dependency updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY package.json /verrazzano/
 WORKDIR /verrazzano/
 
 RUN npm install --save express express-http-proxy \
+    && npm prune --production \
     && rm -rf /usr/bin/npm /usr/lib/node_modules/npm
 
 HEALTHCHECK --interval=1m --timeout=10s \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,7 @@ COPY generate-env.js /verrazzano/
 COPY package.json /verrazzano/
 WORKDIR /verrazzano/
 
-RUN npm install --save express express-http-proxy \
-    && npm prune --production \
+RUN npm install --production --save express express-http-proxy \
     && rm -rf /usr/bin/npm /usr/lib/node_modules/npm
 
 HEALTHCHECK --interval=1m --timeout=10s \

--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,8 @@ ojet-build: npm-install
 	ojet build --release
 	./calc_integrity_hash.sh
 
-.PHONY: npm-prune
-npm-prune:
-	npm prune --production
-
 .PHONY: build
-build: ojet-build npm-prune
+build: ojet-build
 	docker build --pull \
 		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} .
 

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,12 @@ ojet-build: npm-install
 	ojet build --release
 	./calc_integrity_hash.sh
 
+.PHONY: npm-prune
+npm-prune:
+	npm prune --production
+
 .PHONY: build
-build: ojet-build
+build: ojet-build npm-prune
 	docker build --pull \
 		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} .
 

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "1.0.0",
   "description": "An Oracle JavaScript Extension Toolkit(JET) web app",
   "dependencies": {
-    "@oracle/ojet-cli": "^10.1.0",
     "@oracle/oraclejet": "10.1.0",
     "express": "4.17.1",
     "express-http-proxy": "1.6.2",
     "js-yaml": "3.14.0"
   },
   "devDependencies": {
+    "@oracle/ojet-cli": "^10.1.0",
     "@oracle/oraclejet-tooling": "10.1.0",
     "@types/chai": "^4.2.3",
     "@types/js-yaml": "^3.12.5",


### PR DESCRIPTION
Move the `ojet-cli` module to devDependencies, change `npm install` command to use `--production` switch so that dev dependencies are removed in the image.