### PR TITLE
VZ-8499: Dependency updates (#259) (release-1.5)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY generate-env.js /verrazzano/
 COPY package.json /verrazzano/
 WORKDIR /verrazzano/
 
-RUN npm install --save express express-http-proxy \
+RUN npm install --production --save express express-http-proxy \
     && rm -rf /usr/bin/npm /usr/lib/node_modules/npm
 
 HEALTHCHECK --interval=1m --timeout=10s \

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "1.0.0",
   "description": "An Oracle JavaScript Extension Toolkit(JET) web app",
   "dependencies": {
-    "@oracle/ojet-cli": "^10.1.0",
     "@oracle/oraclejet": "10.1.0",
     "express": "4.17.1",
     "express-http-proxy": "1.6.2",
     "js-yaml": "3.14.0"
   },
   "devDependencies": {
+    "@oracle/ojet-cli": "^10.1.0",
     "@oracle/oraclejet-tooling": "10.1.0",
     "@types/chai": "^4.2.3",
     "@types/js-yaml": "^3.12.5",


### PR DESCRIPTION
Cherry-pick commit to make the ojet-cli a dev dependency and to use the `--production` flag on `npm install` to eliminate non-essential node modules.