### PR TITLE
VZ-10903: Send empty json object for 404 responses

### DIFF
--- a/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
+++ b/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
@@ -380,6 +380,8 @@ export class VerrazzanoApi {
     retry = 5
   ): Promise<Response> {
     const response = await this.callFetchAPI(type, namespace, name);
+    const emptyElement = {};
+    const emptyCollection = { items: [] };
     if (retry === 0) {
       throw new VzError(
         Messages.Error.errFetchingKubernetesResource(
@@ -399,9 +401,9 @@ export class VerrazzanoApi {
 
     if (response && response.status === 404) {
       if (name) {
-        return new Response(JSON.parse("{}"));
+        return new Response(JSON.stringify(emptyElement));
       }
-      return new Response(JSON.parse('{"items": []}'));
+      return new Response(JSON.stringify(emptyCollection));
     }
 
     if (!response || response.status >= 400) {

--- a/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
+++ b/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
@@ -402,11 +402,13 @@ export class VerrazzanoApi {
     }
 
     if (!response || response.status >= 400) {
+      console.log("coming here");
       setTimeout(() => {
         return this.getKubernetesResource(type, namespace, name, retry - 1);
       }, interval);
     }
 
+    console.log("coming here first");
     return response;
   }
 

--- a/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
+++ b/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
@@ -406,10 +406,9 @@ export class VerrazzanoApi {
       setTimeout(() => {
         return this.getKubernetesResource(type, namespace, name, retry - 1);
       }, interval);
+    } else {
+      return response;
     }
-
-    console.log("coming here first");
-    return response;
   }
 
   public async postKubernetesResource(

--- a/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
+++ b/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
@@ -104,8 +104,8 @@ export class VerrazzanoApi {
 
       const mcApps = mcAppsObj.items || [];
       const mcComponents = mcComponentsObj.items || [];
-      const apps = appsObj.items;
-      const components = componentsObj.items;
+      const apps = appsObj.items || [];
+      const components = componentsObj.items || [];
 
       const mcApplicationsByClusterAndNamespace = this.collectMulticlusterAppsByClusterAndNamespace(
         mcApps
@@ -385,7 +385,10 @@ export class VerrazzanoApi {
     if (retry === 0) {
       console.log("retry is " + retry);
       if (response?.status === 404) {
-        return <Response>{};
+        if (name) {
+          return <Response>{};
+        }
+        return <Response>(<{}>[]);
       }
 
       throw new VzError(

--- a/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
+++ b/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
@@ -36,7 +36,7 @@ export class VerrazzanoApi {
   public async getInstance(instanceId: string): Promise<Instance> {
     return Promise.all([this.getKubernetesResource(ResourceType.Verrazzano)])
       .then(([vzResponse]) => {
-        return Promise.all([vzResponse.json()]);
+        return Promise.all([vzResponse.json ? vzResponse.json() : [{}]]);
       })
       .then(([vzs]) => {
         // There can be only one installed Verrazzano instance, but we don't know
@@ -80,8 +80,8 @@ export class VerrazzanoApi {
         mcAppsObj,
         mcComponentsObj,
       ] = await Promise.all([
-        appsResponse.json(),
-        compsResponse.json(),
+        appsResponse.json ? appsResponse.json() : [{}],
+        compsResponse.json ? compsResponse.json() : [{}],
         mcAppsResponse.json ? mcAppsResponse.json() : [{}],
         mcCompsResponse.json ? mcCompsResponse.json() : [{}],
       ]);
@@ -236,7 +236,7 @@ export class VerrazzanoApi {
             const resource = await new VerrazzanoApi(
               cluster
             ).getKubernetesResource(ResourceType.Component, namespace, name);
-            const component = await resource.json();
+            const component = await (resource.json ? resource.json() : {});
             mcComponents.set(name, component);
           } catch (error) {
             console.log(
@@ -258,7 +258,7 @@ export class VerrazzanoApi {
               namespace,
               name
             );
-            const app = await resource.json();
+            const app = await (resource.json ? resource.json() : {});
             mcApps.set(name, app);
             const appComponents = this.findComponentsForMcApp(
               app,
@@ -271,7 +271,9 @@ export class VerrazzanoApi {
                   namespace,
                   appComp.metadata.name
                 );
-                const comp = await compResource?.json();
+                const comp = await (compResource?.json
+                  ? compResource?.json()
+                  : {});
                 appComponentsPerNS.push(comp);
               }
             }
@@ -300,7 +302,7 @@ export class VerrazzanoApi {
   public async listClusters(): Promise<Cluster[]> {
     return this.getKubernetesResource(ResourceType.Cluster)
       .then((clusterResponse) => {
-        return clusterResponse.json();
+        return clusterResponse.json ? clusterResponse.json() : [{}];
       })
       .then((clustersResponse) => {
         return processClusterData(clustersResponse.items);
@@ -505,7 +507,7 @@ export class VerrazzanoApi {
       clusterName
     )
       .then((vmcResponse) => {
-        return vmcResponse.json();
+        return vmcResponse.json ? vmcResponse.json() : { Object };
       })
       .then((vmc) => {
         if (!vmc) {
@@ -534,7 +536,7 @@ export class VerrazzanoApi {
   public async listProjects(): Promise<Project[]> {
     return this.getKubernetesResource(ResourceType.VerrazzanoProject)
       .then((projectsResponse) => {
-        return projectsResponse.json();
+        return projectsResponse.json ? projectsResponse.json() : [{}];
       })
       .then((projects) => {
         if (!projects) {
@@ -551,7 +553,7 @@ export class VerrazzanoApi {
   public async listImageBuildRequests(): Promise<ImageBuildRequest[]> {
     return this.getKubernetesResource(ResourceType.VerrazzanoImageBuildRequest)
       .then((buildRequestResponse) => {
-        return buildRequestResponse.json();
+        return buildRequestResponse.json ? buildRequestResponse.json() : [{}];
       })
       .then((imageBuildRequests) => {
         if (!imageBuildRequests) {
@@ -567,7 +569,7 @@ export class VerrazzanoApi {
   public async listRoleBindings(namespace: string): Promise<RoleBinding[]> {
     return this.getKubernetesResource(ResourceType.RoleBinding, namespace)
       .then((rbResponse) => {
-        return rbResponse.json();
+        return rbResponse.json ? rbResponse.json() : [{}];
       })
       .then((roleBindings) => {
         if (!roleBindings) {

--- a/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
+++ b/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
@@ -23,7 +23,7 @@ import * as Messages from "vz-console/utils/Messages";
 import { VzError } from "vz-console/utils/error";
 
 export const ServicePrefix = "instances";
-var empty: Object = {}
+var empty: Object = {};
 
 export class VerrazzanoApi {
   private fetchApi: FetchApiSignature;
@@ -353,14 +353,18 @@ export class VerrazzanoApi {
   ): Promise<Response> {
     return Promise.resolve(
       this.fetchApi(
-        `${this.url}/${type.ApiVersion}/${namespace
-          ? `namespaces/${namespace}/${type.Kind.toLowerCase()}${type.Kind.endsWith("s") ? "es" : "s"
-          }`
-          : `${type.Kind.toLowerCase()}${type.Kind.endsWith("s") ? "es" : "s"
-          }`
-        }${name ? `/${name}` : ""}${this.cluster && this.cluster !== "local"
-          ? `?cluster=${this.cluster}`
-          : ""
+        `${this.url}/${type.ApiVersion}/${
+          namespace
+            ? `namespaces/${namespace}/${type.Kind.toLowerCase()}${
+                type.Kind.endsWith("s") ? "es" : "s"
+              }`
+            : `${type.Kind.toLowerCase()}${
+                type.Kind.endsWith("s") ? "es" : "s"
+              }`
+        }${name ? `/${name}` : ""}${
+          this.cluster && this.cluster !== "local"
+            ? `?cluster=${this.cluster}`
+            : ""
         }`,
         { credentials: "include" }
       )
@@ -409,10 +413,12 @@ export class VerrazzanoApi {
     namespace?: string
   ): Promise<Response> {
     const response = await this.fetchApi(
-      `${this.url}/${type.ApiVersion}/${namespace
-        ? `namespaces/${namespace}/${type.Kind.toLowerCase()}${type.Kind.endsWith("s") ? "es" : "s"
-        }`
-        : `${type.Kind.toLowerCase()}${type.Kind.endsWith("s") ? "es" : "s"}`
+      `${this.url}/${type.ApiVersion}/${
+        namespace
+          ? `namespaces/${namespace}/${type.Kind.toLowerCase()}${
+              type.Kind.endsWith("s") ? "es" : "s"
+            }`
+          : `${type.Kind.toLowerCase()}${type.Kind.endsWith("s") ? "es" : "s"}`
       }`,
       {
         method: "POST",

--- a/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
+++ b/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
@@ -383,7 +383,6 @@ export class VerrazzanoApi {
   ): Promise<Response> {
     const response = await this.callFetchAPI(type, namespace, name);
     if (retry === 0) {
-      console.log("retry is " + retry);
       if (response?.status === 404) {
         if (name) {
           return <Response>{};

--- a/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
+++ b/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
@@ -31,6 +31,7 @@ export class VerrazzanoApi {
   private defaultUrl: string;
   private url: string;
   private cluster: string = "local";
+  private delay = () => new Promise((resolve) => setTimeout(resolve, 1000));
 
   public async getInstance(instanceId: string): Promise<Instance> {
     return Promise.all([this.getKubernetesResource(ResourceType.Verrazzano)])
@@ -378,9 +379,9 @@ export class VerrazzanoApi {
     name?: string,
     retry = 5
   ): Promise<Response> {
-    const interval = 1000;
     const response = await this.callFetchAPI(type, namespace, name);
     if (retry === 0) {
+      console.log("retry is " + retry);
       if (response?.status === 404) {
         return <Response>{};
       }
@@ -402,10 +403,9 @@ export class VerrazzanoApi {
     }
 
     if (!response || response.status >= 400) {
-      console.log("coming here");
-      setTimeout(() => {
-        return this.getKubernetesResource(type, namespace, name, retry - 1);
-      }, interval);
+      return this.delay().then(() =>
+        this.getKubernetesResource(type, namespace, name, retry - 1)
+      );
     } else {
       return response;
     }

--- a/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
+++ b/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
@@ -399,9 +399,9 @@ export class VerrazzanoApi {
 
     if (response && response.status === 404) {
       if (name) {
-        return new Response(JSON.stringify("{}"));
+        return new Response(JSON.parse("{}"));
       }
-      return new Response(JSON.stringify('{"items": []}'));
+      return new Response(JSON.parse('{"items": []}'));
     }
 
     if (!response || response.status >= 400) {

--- a/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
+++ b/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
@@ -385,9 +385,9 @@ export class VerrazzanoApi {
     if (retry === 0) {
       if (response?.status === 404) {
         if (name) {
-          return <Response>{};
+          return new Response(JSON.stringify("{}"));
         }
-        return <Response>(<{}>[]);
+        return new Response(JSON.stringify("[]"));
       }
 
       throw new VzError(

--- a/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
+++ b/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
@@ -104,8 +104,8 @@ export class VerrazzanoApi {
 
       const mcApps = mcAppsObj.items || [];
       const mcComponents = mcComponentsObj.items || [];
-      const apps = appsObj.items;
-      const components = componentsObj.items;
+      const apps = appsObj.items || [];
+      const components = componentsObj.items || [];
 
       const mcApplicationsByClusterAndNamespace = this.collectMulticlusterAppsByClusterAndNamespace(
         mcApps
@@ -303,7 +303,9 @@ export class VerrazzanoApi {
         return clusterResponse.json ? clusterResponse.json() : [empty];
       })
       .then((clustersResponse) => {
-        return processClusterData(clustersResponse.items);
+        return clustersResponse.items
+          ? processClusterData(clustersResponse.items)
+          : [empty];
       })
       .catch((error) => {
         throw this.wrapWithVzError(error);
@@ -537,7 +539,7 @@ export class VerrazzanoApi {
           throw new Error(Messages.Error.errProjectsFetchError());
         }
 
-        return processProjectsData(projects.items);
+        return projects.items ? processProjectsData(projects.items) : [empty];
       })
       .catch((error) => {
         throw this.wrapWithVzError(error);

--- a/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
+++ b/src/ts/jet-composites/vz-console/service/VerrazzanoApi.ts
@@ -387,7 +387,7 @@ export class VerrazzanoApi {
         if (name) {
           return new Response(JSON.stringify("{}"));
         }
-        return new Response(JSON.stringify("[]"));
+        return new Response(JSON.stringify('{"items": []}'));
       }
 
       throw new VzError(


### PR DESCRIPTION
- In case when a CRD for a resource is not installed, the api server sends `404 page not found` which does not gets parsed as valid json. Changed the logic to transform the response for 404's
- The existing `setTimeout` loop is not working since it spawns separate async calls not returning into the function and hence effectively retry not happening at all. Changed that to a simple delay based approach
- Resolved a static linting error for arary objects