### PR TITLE
VZ-11484: Use distroless base as final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (C) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 FROM ghcr.io/oracle/oraclelinux:8-slim AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM ghcr.io/oracle/oraclelinux:8-slim
+FROM ghcr.io/oracle/oraclelinux:8-slim AS builder
 
 RUN microdnf update -y \
     && microdnf module enable nodejs:16 \
@@ -15,23 +15,30 @@ RUN microdnf update -y \
     && chown -R 1000:verrazzano /verrazzano \
     && chown -R 1000:verrazzano /licenses
 
-
-COPY LICENSE.txt README.md THIRD_PARTY_LICENSES.txt SECURITY.md /licenses/
-
-COPY web /verrazzano/web
-COPY livenessProbe.sh /verrazzano/
-COPY start.sh /verrazzano/
-COPY server.js /verrazzano/
-COPY generate-env.js /verrazzano/
-COPY package.json /verrazzano/
 WORKDIR /verrazzano/
 
 RUN npm install --production --save express express-http-proxy \
     && npm cache clean --force \
     && rm -rf /usr/bin/npm /usr/lib/node_modules/npm
 
-HEALTHCHECK --interval=1m --timeout=10s \
-  CMD /verrazzano/livenessProbe.sh
+FROM ghcr.io/verrazzano/ol8-base:v0.0.1-20231102152128-e7afc807
+
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+
+COPY --from=builder /usr/bin/node /usr/bin/
+COPY --from=builder /usr/lib64/libbrot* /usr/lib64/
+COPY --from=builder /usr/lib64/libstdc++* /usr/lib64/
+
+COPY --from=builder /verrazzano/node_modules/ /verrazzano/node_modules/
+
+COPY LICENSE.txt README.md THIRD_PARTY_LICENSES.txt SECURITY.md /licenses/
+
+COPY web /verrazzano/web
+COPY start.sh /verrazzano/
+COPY server.js /verrazzano/
+COPY generate-env.js /verrazzano/
+COPY package.json /verrazzano/
 
 USER 1000
 WORKDIR /verrazzano/


### PR DESCRIPTION
This PR updates the Dockerfile to use the distroless base image as the final image. Note that I also removed the HEALTHCHECK directive because Kubernetes explicitly disables it, so it was serving no purpose.